### PR TITLE
Update PhoneNumberKit/PhoneNumberKitCore version

### DIFF
--- a/packages/flutter_libphonenumber_ios/CHANGELOG.md
+++ b/packages/flutter_libphonenumber_ios/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.1.4
-* Bump PhoneNumberKit to 3.6.3.
+* Bump PhoneNumberKit to `~> 3.6.1`.
 
 # 1.1.3
 * Bump PhoneNumberKit to 3.6.0.

--- a/packages/flutter_libphonenumber_ios/CHANGELOG.md
+++ b/packages/flutter_libphonenumber_ios/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.4
+* Bump PhoneNumberKit to 3.6.1.
+
 # 1.1.3
 * Bump PhoneNumberKit to 3.6.0.
 

--- a/packages/flutter_libphonenumber_ios/CHANGELOG.md
+++ b/packages/flutter_libphonenumber_ios/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.1.4
-* Bump PhoneNumberKit to 3.6.1.
+* Bump PhoneNumberKit to 3.6.3.
 
 # 1.1.3
 * Bump PhoneNumberKit to 3.6.0.

--- a/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
+++ b/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source = { :path => "." }
   s.source_files = "Classes/**/*"
   s.dependency "Flutter"
-  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "3.6.3"
+  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "~> 3.6.1"
   s.platform = :ios, "9.0"
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.

--- a/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
+++ b/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source = { :path => "." }
   s.source_files = "Classes/**/*"
   s.dependency "Flutter"
-  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "3.6.0"
+  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "3.6.1"
   s.platform = :ios, "9.0"
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.

--- a/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
+++ b/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source = { :path => "." }
   s.source_files = "Classes/**/*"
   s.dependency "Flutter"
-  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "3.6.1"
+  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "3.6.3"
   s.platform = :ios, "9.0"
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.

--- a/packages/flutter_libphonenumber_ios/pubspec.yaml
+++ b/packages/flutter_libphonenumber_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_libphonenumber_ios
 description: iOS implementation of the flutter_libphonenumber plugin.
 repository: https://github.com/bottlepay/flutter_libphonenumber/tree/main/packages/flutter_libphonenumber_ios
 issue_tracker: https://github.com/bottlepay/flutter_libphonenumber/issues
-version: 1.1.3
+version: 1.1.4
 
 environment:
   sdk: ">=2.19.0 <4.0.0"


### PR DESCRIPTION
When running `pod install --repo-update` I get the following error:

```console
[!] CocoaPods could not find compatible versions for pod "PhoneNumberKit/PhoneNumberKitCore":
  In snapshot (Podfile.lock):
    PhoneNumberKit/PhoneNumberKitCore (= 3.6.1)

  In Podfile:
    PhoneNumberKit (from `https://github.com/marmelroy/PhoneNumberKit`) was resolved to 3.6.1, which depends on
      PhoneNumberKit/PhoneNumberKitCore (= 3.6.1)

    flutter_libphonenumber_ios (from `.symlinks/plugins/flutter_libphonenumber_ios/ios`) was resolved to 1.1.0, which depends on
      PhoneNumberKit/PhoneNumberKitCore (= 3.6.0)

Specs satisfying the `PhoneNumberKit/PhoneNumberKitCore (= 3.6.1), PhoneNumberKit/PhoneNumberKitCore (= 3.6.0)` dependency were found, but they required a higher minimum deployment target.
```

And this PR fixes it...