### PR TITLE
Update flutter_libphonenumber_ios.podspec

### DIFF
--- a/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
+++ b/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source = { :path => "." }
   s.source_files = "Classes/**/*"
   s.dependency "Flutter"
-  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "3.6.0"
+  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "3.6.1"
   s.platform = :ios, "9.0"
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.


### PR DESCRIPTION
Fixes:

```
[!] CocoaPods could not find compatible versions for pod "PhoneNumberKit/PhoneNumberKitCore":
  In Podfile:
    PhoneNumberKit (from `https://github.com/marmelroy/PhoneNumberKit`) was resolved to 3.6.1, which depends on
      PhoneNumberKit/PhoneNumberKitCore (= 3.6.1)

    flutter_libphonenumber_ios (from `.symlinks/plugins/flutter_libphonenumber_ios/ios`) was resolved to 1.1.0, which depends on
      PhoneNumberKit/PhoneNumberKitCore (= 3.6.0)

Specs satisfying the `PhoneNumberKit/PhoneNumberKitCore (= 3.6.0), PhoneNumberKit/PhoneNumberKitCore (= 3.6.1)` dependency were found, but they required a higher minimum deployment target.
```