### PR TITLE
iOS - Added Privacy Manifest

### DIFF
--- a/packages/flutter_libphonenumber_ios/CHANGELOG.md
+++ b/packages/flutter_libphonenumber_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.1
+* Bump PhoneNumberKit to 3.7.9
+* Added a Privacy Manifest to the iOS Project
+
 # 1.2.0
 * Bump PhoneNumberKit to 3.7.6.
 * *BREAKING* Raises minimum iOS deployment to 12.0.

--- a/packages/flutter_libphonenumber_ios/ios/Resources/PrivacyInfo.xcprivacy
+++ b/packages/flutter_libphonenumber_ios/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
+++ b/packages/flutter_libphonenumber_ios/ios/flutter_libphonenumber_ios.podspec
@@ -15,10 +15,11 @@ Pod::Spec.new do |s|
   s.source = { :path => "." }
   s.source_files = "Classes/**/*"
   s.dependency "Flutter"
-  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "3.7.6"
+  s.dependency "PhoneNumberKit/PhoneNumberKitCore", "3.7.9"
   s.platform = :ios, "12.0"
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES", "VALID_ARCHS[sdk=iphonesimulator*]" => "x86_64" }
   s.swift_version = "5.0"
+  s.resource_bundles = {'flutter_libphonenumber_ios' => ['Resources/PrivacyInfo.xcprivacy']}
 end

--- a/packages/flutter_libphonenumber_ios/pubspec.yaml
+++ b/packages/flutter_libphonenumber_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_libphonenumber_ios
 description: iOS implementation of the flutter_libphonenumber plugin.
 repository: https://github.com/bottlepay/flutter_libphonenumber/tree/main/packages/flutter_libphonenumber_ios
 issue_tracker: https://github.com/bottlepay/flutter_libphonenumber/issues
-version: 1.2.0
+version: 1.2.1
 
 environment:
   sdk: ">=2.19.0 <4.0.0"


### PR DESCRIPTION
# Summary
Added an empty Privacy Manifest to the iOS project in preparation for the May 1st Deadline for 3rd Party SDKs that include native iOS code. 

Additionally, bumped `PhoneNumberKit/PhoneNumberKitCore` to [3.7.9](https://github.com/marmelroy/PhoneNumberKit/releases/tag/3.7.9), which contains Privacy Manifests for that library as well.

# Description

> Starting May 1: You’ll need to include approved reasons for the listed APIs used by your app’s code to upload a new or updated app to App Store Connect.
> ...
> Make sure to use a version of the SDK that includes its privacy manifest and note that signatures are also required when the SDK is added as a binary dependency.

[Privacy updates for App Store submissions - Latest News - Apple Developer](https://developer.apple.com/news/?id=3d8a9yyh)
[Upcoming third-party SDK requirements - Support - Apple Developer](https://developer.apple.com/support/third-party-SDK-requirements/)

# Impact and Testing
Developers using an updated version of this library on their iOS projects shouldn't see any issues related to the Privacy Manifest

# Contributor Note
Based on the language on Apple's Website, this change seems to be mandatory for all 3rd Party Libraries. The impact of not adding it is unclear to me, but hopefully having it will be better than not.