### PR TITLE
Ability to recognize country when inserting a phone number

### DIFF
--- a/packages/flutter_libphonenumber_platform_interface/lib/src/types/input_formatter.dart
+++ b/packages/flutter_libphonenumber_platform_interface/lib/src/types/input_formatter.dart
@@ -11,6 +11,7 @@ class LibPhonenumberTextFormatter extends TextInputFormatter {
     this.phoneNumberType = PhoneNumberType.mobile,
     this.phoneNumberFormat = PhoneNumberFormat.international,
     this.onFormatFinished,
+    this.onCountryRecognized,
     this.inputContainsCountryCode = false,
 
     /// Additional digits to include
@@ -49,6 +50,10 @@ class LibPhonenumberTextFormatter extends TextInputFormatter {
   /// Optional function to execute after we are finished formatting the number.
   /// Useful if you need to get the formatted value for something else to use.
   final FutureOr Function(String val)? onFormatFinished;
+
+  /// Optional callback that is called when it is possible to recognize the country as a result
+  /// of selecting a phone number from OS autofill suggestions or pasting from the clipboard
+  final void Function(CountryWithPhoneCode country)? onCountryRecognized;
 
   /// When true, mask will be applied assuming the input contains a country code in it.
   final bool inputContainsCountryCode;

--- a/packages/flutter_libphonenumber_platform_interface/lib/src/types/input_formatter.dart
+++ b/packages/flutter_libphonenumber_platform_interface/lib/src/types/input_formatter.dart
@@ -73,6 +73,14 @@ class LibPhonenumberTextFormatter extends TextInputFormatter {
     final TextEditingValue oldValue,
     final TextEditingValue newValue,
   ) {
+
+    /// First, let's try to recognize the whole number
+    final recognizedValue = _tryRecognizePhoneWithCountry(oldValue, newValue);
+    if (recognizedValue != null) {
+      return recognizedValue;
+    }
+
+
     late final TextEditingValue result;
 
     /// Apply mask to the input

--- a/packages/flutter_libphonenumber_platform_interface/lib/src/types/input_formatter.dart
+++ b/packages/flutter_libphonenumber_platform_interface/lib/src/types/input_formatter.dart
@@ -11,10 +11,7 @@ class LibPhonenumberTextFormatter extends TextInputFormatter {
     this.phoneNumberType = PhoneNumberType.mobile,
     this.phoneNumberFormat = PhoneNumberFormat.international,
     this.onFormatFinished,
-
-    /// When true, mask will be applied assuming the input contains
-    /// a country code in it.
-    final bool inputContainsCountryCode = false,
+    this.inputContainsCountryCode = false,
 
     /// Additional digits to include
     this.additionalDigits = 0,
@@ -52,6 +49,9 @@ class LibPhonenumberTextFormatter extends TextInputFormatter {
   /// Optional function to execute after we are finished formatting the number.
   /// Useful if you need to get the formatted value for something else to use.
   final FutureOr Function(String val)? onFormatFinished;
+
+  /// When true, mask will be applied assuming the input contains a country code in it.
+  final bool inputContainsCountryCode;
 
   /// Allow additional digits on the end of the mask. This is useful for countries like Austria where the
   /// libphonenumber example number doesn't include all of the possibilities. This way we can still format

--- a/packages/flutter_libphonenumber_platform_interface/lib/src/types/recognize_country_data_by_phone.dart
+++ b/packages/flutter_libphonenumber_platform_interface/lib/src/types/recognize_country_data_by_phone.dart
@@ -1,0 +1,30 @@
+import 'package:dlibphonenumber/dlibphonenumber.dart';
+// import 'package:collection/collection.dart'; // firstWhereOrNull extension
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter_libphonenumber_platform_interface/flutter_libphonenumber_platform_interface.dart';
+
+/// Original method CountryWithPhoneCode.getCountryDataByPhone(phone)
+/// has bad implementation because it based in substring comparison.
+///
+/// For example for USA numbers it returns Bahamas, because these countries has same prefix
+/// but Bahamas is alphabetically first
+CountryWithPhoneCode? recognizeCountryDataByPhone(final String phone) {
+  // working with dlibphonenumber
+  final PhoneNumberUtil phoneUtil = PhoneNumberUtil.instance;
+  final PhoneNumber number;
+  try {
+    number = phoneUtil.parse(phone, 'ZZ');
+  } on NumberParseException catch (e) {
+    if (kDebugMode) print('NumberParseException was thrown: ${e.toString()}');
+    return null;
+  }
+
+  // working with flutter_libphonenumber
+  final String? regionCode = phoneUtil.getRegionCodeForNumber(number);
+  // print('regionCode: $regionCode');
+  if (regionCode != null) {
+    final country = CountryManager().countries.firstWhereOrNull((country) => country.countryCode == regionCode);
+    return country;
+  }
+  return null;
+}

--- a/packages/flutter_libphonenumber_platform_interface/lib/src/types/recognize_country_data_by_phone.dart
+++ b/packages/flutter_libphonenumber_platform_interface/lib/src/types/recognize_country_data_by_phone.dart
@@ -1,5 +1,5 @@
 import 'package:dlibphonenumber/dlibphonenumber.dart';
-// import 'package:collection/collection.dart'; // firstWhereOrNull extension
+// import 'package:collection/collection.dart'; // firstWhereOrNull extension, avoid dependency for one method
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter_libphonenumber_platform_interface/flutter_libphonenumber_platform_interface.dart';
 
@@ -23,8 +23,22 @@ CountryWithPhoneCode? recognizeCountryDataByPhone(final String phone) {
   final String? regionCode = phoneUtil.getRegionCodeForNumber(number);
   // print('regionCode: $regionCode');
   if (regionCode != null) {
-    final country = CountryManager().countries.firstWhereOrNull((country) => country.countryCode == regionCode);
+    final country = CountryManager().countries.firstWhereOrNull((final country) => country.countryCode == regionCode);
     return country;
   }
   return null;
+}
+
+
+/// part of https://pub.dev/packages/collection
+extension IterableExtension<T> on Iterable<T> {
+  /// The first element satisfying [test], or `null` if there are none.
+  T? firstWhereOrNull(final bool Function(T element) test) {
+    for (final element in this) {
+      if (test(element)) {
+        return element;
+      }
+    }
+    return null;
+  }
 }

--- a/packages/flutter_libphonenumber_platform_interface/pubspec.yaml
+++ b/packages/flutter_libphonenumber_platform_interface/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
+  dlibphonenumber: ^1.1.12
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.4

--- a/packages/flutter_libphonenumber_web/CHANGELOG.md
+++ b/packages/flutter_libphonenumber_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Bump JS package.
+
 ## 1.0.0
 
-* Initial implementation by laynor.
+- Initial implementation by laynor.

--- a/packages/flutter_libphonenumber_web/pubspec.yaml
+++ b/packages/flutter_libphonenumber_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_libphonenumber_web
 description: Web implementation of the flutter_libphonenumber plugin.
 repository: https://github.com/bottlepay/flutter_libphonenumber/tree/main/packages/flutter_libphonenumber_web
 issue_tracker: https://github.com/bottlepay/flutter_libphonenumber/issues
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ">=2.19.0 <4.0.0"


### PR DESCRIPTION
When code user provides autofillHints telephoneNumber iOS automatically suggests end user's phone from their contact card (Phone -> Contacts -> My Card)

```dart
TextFormField(
  autofillHints: const [
    AutofillHints.telephoneNumber,
  ],
  inputFormatters: [
    LibPhonenumberTextFormatter(
      country: libphonenumber.CountryManager().countries.firstWhere((c) => c.countryCode == 'AE')
    ),
  ],
  ...
)
```

In this case, the `LibPhonenumberTextFormatter` treats the prefix as part of the number and removes the ending. But it would be great if, when inserting, the country was automatically recognized and the appropriate mask was applied. You can see an example in this GIF

For these purposes I added [dlibphonenumber](https://pub.dev/packages/dlibphonenumber) package dependency. Which is a dart port of the [google/libphonenumber](https://github.com/google/libphonenumber) original library

<img src="https://github.com/acoutts/flutter_libphonenumber/assets/4938316/0c506472-2aab-4bca-a4ce-0add944bb975" alt="autofill-phone" width="300" height="auto">