### PR TITLE
[WASM] migrate to package:web and dart:js_interop

### DIFF
--- a/packages/flutter_libphonenumber_web/example/pubspec.yaml
+++ b/packages/flutter_libphonenumber_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the flutter_libphonenumber_web plugin.
 publish_to: none
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=3.0.0"
 
 dependencies:

--- a/packages/flutter_libphonenumber_web/example/web/index.html
+++ b/packages/flutter_libphonenumber_web/example/web/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the
@@ -18,42 +19,23 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="Demonstrates how to use the flutter_libphonenumber_web plugin.">
+  <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="flutter_libphonenumber_web_example">
+  <meta name="apple-mobile-web-app-title" content="example">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+  <link rel="icon" type="image/png" href="favicon.png" />
 
   <title>flutter_libphonenumber_web_example</title>
   <link rel="manifest" href="manifest.json">
-
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    var serviceWorkerVersion = null;
-  </script>
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer></script>
 </head>
+
 <body>
-  <script>
-    window.addEventListener('load', function(ev) {
-      // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        },
-        onEntrypointLoaded: function(engineInitializer) {
-          engineInitializer.initializeEngine().then(function(appRunner) {
-            appRunner.runApp();
-          });
-        }
-      });
-    });
-  </script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
+
 </html>

--- a/packages/flutter_libphonenumber_web/lib/flutter_libphonenumber_web.dart
+++ b/packages/flutter_libphonenumber_web/lib/flutter_libphonenumber_web.dart
@@ -1,5 +1,4 @@
-import 'dart:html' as html;
-import 'dart:ui';
+import 'dart:js_interop';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_libphonenumber_platform_interface/flutter_libphonenumber_platform_interface.dart';
@@ -8,6 +7,7 @@ import 'package:flutter_libphonenumber_web/src/libphonenumber.dart'
     as phoneutil;
 import 'package:flutter_libphonenumber_web/src/utils.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:web/web.dart';
 
 /// The version of libphonenumber to use
 const String libPhoneNumberVersion = 'b7fe84af9b553f0f2db765a6e20c27fa867a971d';
@@ -29,9 +29,10 @@ class FlutterLibphonenumberPlugin extends FlutterLibphonenumberPlatform {
         contextName: 'libphonenumber',
         url: libPhoneNumberUrl,
         usesRequireJs: true,
-      )
+      ),
     ];
-    final helperScriptTag = html.ScriptElement()
+
+    final helperScriptTag = HTMLScriptElement()
       ..type = 'application/javascript'
       ..text = '''
       function libPhoneNumberFlutterGetRegionDisplayNames(lang) {
@@ -39,7 +40,7 @@ class FlutterLibphonenumberPlugin extends FlutterLibphonenumberPlatform {
       }
     ''';
 
-    html.document.head!.append(helperScriptTag);
+    document.head!.append(helperScriptTag);
     _jsLibrariesLoadingFuture = injectJSLibraries(libraries);
   }
 
@@ -75,9 +76,11 @@ class FlutterLibphonenumberPlugin extends FlutterLibphonenumberPlatform {
     final res = <String, CountryWithPhoneCode>{};
 
     final displayNames = phoneutil
-        .libPhoneNumberFlutterGetRegionDisplayNames(window.locale.languageCode);
+        .libPhoneNumberFlutterGetRegionDisplayNames(window.navigator.language);
 
-    for (final region in util.getSupportedRegions()) {
+    final regions = util.getSupportedRegions().toDart;
+    for (final regionJs in regions) {
+      final region = regionJs.toDart;
       final exampleNumberMobile = util.getExampleNumberForType(
             region,
             phoneutil.PhoneNumberType.MOBILE,
@@ -162,6 +165,8 @@ class FlutterLibphonenumberPlugin extends FlutterLibphonenumberPlatform {
           .format(phoneNumber, phoneutil.PhoneNumberFormat.NATIONAL);
 
   static String _formatInternational(final phoneutil.PhoneNumber phoneNumber) =>
-      phoneutil.PhoneNumberUtil.getInstance()
-          .format(phoneNumber, phoneutil.PhoneNumberFormat.INTERNATIONAL);
+      phoneutil.PhoneNumberUtil.getInstance().format(
+        phoneNumber,
+        phoneutil.PhoneNumberFormat.INTERNATIONAL,
+      );
 }

--- a/packages/flutter_libphonenumber_web/lib/src/base.dart
+++ b/packages/flutter_libphonenumber_web/lib/src/base.dart
@@ -28,8 +28,6 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import 'package:js/js.dart';
-
 class JsLibrary {
   const JsLibrary({
     required this.contextName,
@@ -46,19 +44,4 @@ class JsLibrary {
   /// E.g. if at the beginning you see code like
   /// if (typeof define === "function" && define.amd)
   final bool usesRequireJs;
-}
-
-@JS('Promise')
-@staticInterop
-class Promise<T> {}
-
-@JS('Map')
-@staticInterop
-class JsMap {
-  external factory JsMap();
-}
-
-extension JsMapExt on JsMap {
-  external void set(final dynamic key, final dynamic value);
-  external dynamic get(final dynamic key);
 }

--- a/packages/flutter_libphonenumber_web/lib/src/libphonenumber.dart
+++ b/packages/flutter_libphonenumber_web/lib/src/libphonenumber.dart
@@ -1,9 +1,7 @@
-// ignore_for_file: non_constant_identifier_names
-
 @JS()
 library libphonenumber;
 
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 @JS()
 external DisplayNames libPhoneNumberFlutterGetRegionDisplayNames(
@@ -11,19 +9,19 @@ external DisplayNames libPhoneNumberFlutterGetRegionDisplayNames(
 );
 
 @JS('Intl.DisplayNames')
-class DisplayNames {
+extension type DisplayNames._(JSObject _) implements JSObject {
   external String of(final String countryCode);
 }
 
 @JS('libphonenumber.PhoneNumber')
-class PhoneNumber {
+extension type PhoneNumber._(JSObject _) implements JSObject {
   external PhoneNumber();
-  external String getCountryCode();
-  external String getNationalNumber();
+  external int getCountryCode();
+  external int getNationalNumber();
 }
 
 @JS('libphonenumber.PhoneNumberFormat')
-class PhoneNumberFormat {
+extension type PhoneNumberFormat._(JSObject _) implements JSObject {
   external static int E164;
   external static int INTERNATIONAL;
   external static int NATIONAL;
@@ -31,7 +29,7 @@ class PhoneNumberFormat {
 }
 
 @JS('libphonenumber.PhoneNumberType')
-class PhoneNumberType {
+extension type PhoneNumberType._(JSObject _) implements JSObject {
   external static int FIXED_LINE;
   external static int MOBILE;
   external static int FIXED_LINE_OR_MOBILE;
@@ -78,16 +76,16 @@ String numberTypeToString(final int type) {
 }
 
 @JS('libphonenumber.AsYouTypeFormatter')
-class AsYouTypeFormatter {
+extension type AsYouTypeFormatter._(JSObject _) implements JSObject {
   external AsYouTypeFormatter(final String? regionCode);
   external void clear();
   external String inputDigit(final String char);
 }
 
 @JS('libphonenumber.PhoneNumberUtil')
-class PhoneNumberUtil {
+extension type PhoneNumberUtil._(JSObject _) implements JSObject {
   external static PhoneNumberUtil getInstance();
-  external Map<String, dynamic> getExampleNumber(final String regionCode);
+  external JSObject getExampleNumber(final String regionCode);
   external PhoneNumber parse(
     final String phoneNumber,
     final String? regionCode,
@@ -99,7 +97,7 @@ class PhoneNumberUtil {
     final int phoneNumberFormat,
   );
   external String getRegionCodeForNumber(final PhoneNumber phoneNumber);
-  external List<String> getSupportedRegions();
+  external JSArray<JSString> getSupportedRegions();
   external int getCountryCodeForRegion(final String? region);
   external PhoneNumber? getExampleNumberForType(
     final String region,
@@ -122,9 +120,9 @@ extension PhoneNumberUtilExt on PhoneNumberUtil {
           'e164': format(phoneNumber, PhoneNumberFormat.E164),
           'international': format(phoneNumber, PhoneNumberFormat.INTERNATIONAL),
           'national': format(phoneNumber, PhoneNumberFormat.NATIONAL),
-          'country_code': phoneNumber.getCountryCode(),
+          'country_code': '${phoneNumber.getCountryCode()}',
           'region_code': getRegionCodeForNumber(phoneNumber),
-          'national_number': phoneNumber.getNationalNumber(),
+          'national_number': '${phoneNumber.getNationalNumber()}',
         };
       }
     } catch (e) {

--- a/packages/flutter_libphonenumber_web/lib/src/utils.dart
+++ b/packages/flutter_libphonenumber_web/lib/src/utils.dart
@@ -29,37 +29,16 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import 'dart:async';
-import 'dart:html' as html;
-import 'dart:js' show context, JsObject;
 
 import 'package:flutter_libphonenumber_web/src/base.dart';
+import 'package:web/web.dart';
 
 Future<void> loadScript(final JsLibrary library) async {
-  dynamic amd;
-  dynamic define;
-  // ignore: avoid_dynamic_calls
-  if (library.usesRequireJs && context['define']?['amd'] != null) {
-    // In dev, requireJs is loaded in. Disable it here.
-    // see https://github.com/dart-lang/sdk/issues/33979
-    define = JsObject.fromBrowserObject(context['define'] as Object);
-    // ignore: avoid_dynamic_calls
-    amd = define['amd'];
-    // ignore: avoid_dynamic_calls
-    define['amd'] = false;
-  }
-  try {
-    await loadScriptUsingScriptTag(library.url);
-  } finally {
-    if (amd != null) {
-      // Re-enable requireJs
-      // ignore: avoid_dynamic_calls
-      define['amd'] = amd;
-    }
-  }
+  await loadScriptUsingScriptTag(library.url);
 }
 
 Future<void> loadScriptUsingScriptTag(final String url) {
-  final script = html.ScriptElement()
+  final script = HTMLScriptElement()
     ..async = true
     ..defer = false
     ..crossOrigin = 'anonymous'
@@ -67,7 +46,7 @@ Future<void> loadScriptUsingScriptTag(final String url) {
     // ignore: unsafe_html
     ..src = url;
 
-  html.document.head!.append(script);
+  document.head!.append(script);
 
   return script.onLoad.first;
 }

--- a/packages/flutter_libphonenumber_web/lib/src/utils.dart
+++ b/packages/flutter_libphonenumber_web/lib/src/utils.dart
@@ -43,7 +43,6 @@ Future<void> loadScriptUsingScriptTag(final String url) {
     ..defer = false
     ..crossOrigin = 'anonymous'
     ..type = 'text/javascript'
-    // ignore: unsafe_html
     ..src = url;
 
   document.head!.append(script);

--- a/packages/flutter_libphonenumber_web/pubspec.yaml
+++ b/packages/flutter_libphonenumber_web/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/bottlepay/flutter_libphonenumber/issues
 version: 1.0.1
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=3.0.0"
 
 flutter:
@@ -22,7 +22,8 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   flutter_libphonenumber_platform_interface: ^1.0.0
-  js: ^0.7.1
+  
+  web: ">=0.5.0 <2.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
In order to [support web assembly](https://docs.flutter.dev/platform-integration/web/wasm), the package need to be migrated to use  `package:web` and `dart:js_interop` instead of `dart:html` and `package:js`