### PR TITLE
Add flutter sdk 3.24 support

### DIFF
--- a/packages/flutter_libphonenumber/pubspec.yaml
+++ b/packages/flutter_libphonenumber/pubspec.yaml
@@ -27,7 +27,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_libphonenumber_android: ^1.0.1
+  flutter_libphonenumber_android: ^1.0.2
   flutter_libphonenumber_ios: ^1.2.1
   flutter_libphonenumber_platform_interface: ^1.0.0
   flutter_libphonenumber_web: ^1.1.0

--- a/packages/flutter_libphonenumber_android/android/build.gradle
+++ b/packages/flutter_libphonenumber_android/android/build.gradle
@@ -29,7 +29,16 @@ android {
         namespace("com.bottlepay.flutter_libphonenumber")
     }
 
-    compileSdkVersion 29
+    compileSdk 34
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/packages/flutter_libphonenumber_android/pubspec.yaml
+++ b/packages/flutter_libphonenumber_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_libphonenumber_android
 description: Android implementation of the flutter_libphonenumber plugin.
 repository: https://github.com/bottlepay/flutter_libphonenumber/tree/main/packages/flutter_libphonenumber_android
 issue_tracker: https://github.com/bottlepay/flutter_libphonenumber/issues
-version: 1.0.1
+version: 1.0.2
 
 environment:
   sdk: ">=2.19.0 <4.0.0"


### PR DESCRIPTION
Adding `compileOptions` and `kotlinOptions` fixes https://github.com/acoutts/flutter_libphonenumber/issues/79. Upgrading `compileSdk` fixes https://github.com/acoutts/flutter_libphonenumber/issues/78

Similar issues in another libs: https://github.com/OneSignal/OneSignal-Flutter-SDK/issues/930