### PR TITLE
Remove registerWith function

### DIFF
--- a/packages/flutter_libphonenumber_android/android/src/main/kotlin/com/bottlepay/flutter_libphonenumber/FlutterLibphonenumberPlugin.kt
+++ b/packages/flutter_libphonenumber_android/android/src/main/kotlin/com/bottlepay/flutter_libphonenumber/FlutterLibphonenumberPlugin.kt
@@ -12,7 +12,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.util.*
 
 
@@ -27,23 +26,6 @@ public class FlutterLibphonenumberPlugin : FlutterPlugin, MethodCallHandler {
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "com.bottlepay/flutter_libphonenumber_android")
     channel.setMethodCallHandler(this);
-  }
-
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
-  companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-      val channel = MethodChannel(registrar.messenger(), "flutter_libphonenumber")
-      channel.setMethodCallHandler(FlutterLibphonenumberPlugin())
-    }
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {


### PR DESCRIPTION
This fixes unresolved Registrar issue occurring after upgrading Flutter to 3.29.0

#91 #92 