### PR TITLE
fix: apply kotlin-android when builtInKotlin=false on AGP 9+

### DIFF
--- a/packages/flutter_libphonenumber_android/android/build.gradle
+++ b/packages/flutter_libphonenumber_android/android/build.gradle
@@ -23,12 +23,12 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-// Apply the Kotlin plugin only on AGP <9: AGP >=9 has built-in Kotlin and
-// Flutter >=3.44 manages Kotlin for plugin projects. On older hosts
-// (Flutter <3.44) the plugin still applies it itself.
-// https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+// Apply the Kotlin plugin unless AGP >=9 has built-in Kotlin enabled.
+// Flutter >=3.44 may set android.builtInKotlin=false during migration,
+// in which case we must still apply it ourselves even on AGP >=9.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = project.findProperty('android.builtInKotlin')
+if (agpMajor < 9 || builtInKotlin == 'false') {
     apply plugin: 'kotlin-android'
 }
 
@@ -55,9 +55,11 @@ android {
     }
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+plugins.withId("org.jetbrains.kotlin.android") {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Build fails with `Could not find method kotlin()` (build.gradle:58) when using:
- AGP 9.x
- Flutter ≥ 3.44

Flutter 3.44 introduced a migration phase where it automatically sets `android.builtInKotlin=false` in `gradle.properties` (via the Flutter migrator tool). This flag disables AGP 9's built-in Kotlin support, so the project still relies on the explicit `kotlin-android` plugin.

However, the plugin's condition `if (agpMajor < 9)` skips applying `kotlin-android` for all AGP 9+ projects — including those where `builtInKotlin=false` is set. As a result, nobody compiles the plugin's Kotlin sources and `FlutterLibphonenumberPlugin` class cannot be found at link time.

## Fix

1. **Condition**:  also apply `kotlin-android` when  `android.builtInKotlin` is explicitly `'false'`, even on AGP 9+:

   ```groovy
   def builtInKotlin = project.findProperty('android.builtInKotlin')
   if (agpMajor < 9 || builtInKotlin == 'false') {
       apply plugin: 'kotlin-android'
   }

2. **Guard**:  wrap the kotlin {} compiler-options block in plugins.withId() so it only executes when the Kotlin plugin is actually present (safe for both the old path and the built-in Kotlin path):
   ```groovy
   plugins.withId("org.jetbrains.kotlin.android") {
       kotlin {
           compilerOptions {
               jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
           }
       }
   }
   ```

## Reproduction

- Flutter 3.44.1, AGP 9.2.1, Gradle 9.4.1
- Run flutter clean && flutter build apk
- Observe: `FAILURE … Could not find method kotlin() for arguments on build.gradle:58`

After this fix the build succeeds with only a deprecation warning
(expected until downstream projects fully migrate to built-in Kotlin).


